### PR TITLE
Update SoapRequestsGenerator.php

### DIFF
--- a/src/SoapRequestsGenerator.php
+++ b/src/SoapRequestsGenerator.php
@@ -638,6 +638,18 @@ class SoapRequestsGenerator {
                         $entityValue->appendChild($executeActionRequestDOM->createElement('b:LogicalName', $entity->LogicalName));
                         $xmlValue = null;
                         break;
+                    
+                    case 'arrayofguid':
+						$xmlType = 'ArrayOfguid';
+						$arrayOfguids = $xmlValue;
+						$xmlTypeNS = 'http://schemas.microsoft.com/2003/10/Serialization/Arrays';
+						$entityValue = $executeActionRequestDOM->createElement('c:value');
+						foreach ( $arrayOfguids as $contact_guid ) {
+							$entityValue->appendChild($executeActionRequestDOM->createElement( 'd:guid', $contact_guid ));
+						}; // end foreach
+						$xmlValue = null;
+						break;
+
                     case 'memo':
                         /* Memo - This gets treated as a normal String */
                         $xmlType = 'string';


### PR DESCRIPTION
adding support in "generateExecuteActionRequest" to handle the xml field type "ArrayOfguid". 

This allow passing an array of this type to the executeAction function which enables us to call the CRM function addListMemberList (which can add multiple guids to a marketing list in one operation)